### PR TITLE
Display only what can be interacted with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Display only what can be interacted with ([#4](https://github.com/scm-manager/scm-ssl-context-plugin/pull/4))
+
 ## 1.1.0 - 2021-06-16
 ### Added
 - Certificate upload ([#2](https://github.com/scm-manager/scm-ssl-context-plugin/pull/2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
-- Display only what can be interacted with ([#4](https://github.com/scm-manager/scm-ssl-context-plugin/pull/4))
+- Add manage permission ([#4](https://github.com/scm-manager/scm-ssl-context-plugin/pull/4))
 
 ## 1.1.0 - 2021-06-16
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@
 
 
 plugins {
-  id 'org.scm-manager.smp' version '0.8.5'
+  id 'org.scm-manager.smp' version '0.9.3'
 }
 
 dependencies {

--- a/src/main/java/com/cloudogu/sslcontext/CertificateMapper.java
+++ b/src/main/java/com/cloudogu/sslcontext/CertificateMapper.java
@@ -106,18 +106,15 @@ public abstract class CertificateMapper extends BaseMapper<Certificate, Certific
   }
 
   private Links createLinks(Certificate certificate, String storedId) {
-    if (PermissionChecker.mayManageSSLContext()) {
-      Links.Builder linksBuilder = linkingTo();
-      if (certificate.getError() == Certificate.Error.UNKNOWN) {
-        if (certificate.getStatus() == Certificate.Status.REJECTED) {
-          linksBuilder.single(link("approve", createLink("approve", storedId, certificate.getFingerprint())));
-        } else {
-          linksBuilder.single(link("reject", createLink("reject", storedId, certificate.getFingerprint())));
-        }
+    Links.Builder linksBuilder = linkingTo();
+    if (PermissionChecker.mayManageSSLContext() && certificate.getError() == Certificate.Error.UNKNOWN) {
+      if (certificate.getStatus() == Certificate.Status.REJECTED) {
+        linksBuilder.single(link("approve", createLink("approve", storedId, certificate.getFingerprint())));
+      } else {
+        linksBuilder.single(link("reject", createLink("reject", storedId, certificate.getFingerprint())));
       }
-      return linksBuilder.build();
     }
-    return null;
+    return linksBuilder.build();
   }
 
   private String createLink(String name, String parentId, String id) {

--- a/src/main/java/com/cloudogu/sslcontext/CertificateMapper.java
+++ b/src/main/java/com/cloudogu/sslcontext/CertificateMapper.java
@@ -106,15 +106,18 @@ public abstract class CertificateMapper extends BaseMapper<Certificate, Certific
   }
 
   private Links createLinks(Certificate certificate, String storedId) {
-    Links.Builder linksBuilder = linkingTo();
-    if (certificate.getError() == Certificate.Error.UNKNOWN) {
-      if (certificate.getStatus() == Certificate.Status.REJECTED) {
-        linksBuilder.single(link("approve", createLink("approve", storedId, certificate.getFingerprint())));
-      } else {
-        linksBuilder.single(link("reject", createLink("reject", storedId, certificate.getFingerprint())));
+    if (PermissionChecker.mayManageSSLContext()) {
+      Links.Builder linksBuilder = linkingTo();
+      if (certificate.getError() == Certificate.Error.UNKNOWN) {
+        if (certificate.getStatus() == Certificate.Status.REJECTED) {
+          linksBuilder.single(link("approve", createLink("approve", storedId, certificate.getFingerprint())));
+        } else {
+          linksBuilder.single(link("reject", createLink("reject", storedId, certificate.getFingerprint())));
+        }
       }
+      return linksBuilder.build();
     }
-    return linksBuilder.build();
+    return null;
   }
 
   private String createLink(String name, String parentId, String id) {

--- a/src/main/java/com/cloudogu/sslcontext/IndexLinkEnricher.java
+++ b/src/main/java/com/cloudogu/sslcontext/IndexLinkEnricher.java
@@ -50,24 +50,29 @@ public class IndexLinkEnricher implements HalEnricher {
   public void enrich(HalEnricherContext context, HalAppender appender) {
 
     if (PermissionChecker.mayReadSSLContext()) {
-      String rejectedSslContextUrl = new LinkBuilder(pathInfoStore.get().get(), SSLContextResource.class)
-        .method("getAllRejected")
-        .parameters()
-        .href();
-      String approvedSslContextUrl = new LinkBuilder(pathInfoStore.get().get(), SSLContextResource.class)
-        .method("getAllApproved")
-        .parameters()
-        .href();
-      String uploadSslContextUrl = new LinkBuilder(pathInfoStore.get().get(), SSLContextResource.class)
-        .method("uploadCertificate")
-        .parameters()
-        .href();
-      appender
-        .linkArrayBuilder("sslContext")
-        .append("rejected", rejectedSslContextUrl)
-        .append("approved", approvedSslContextUrl)
-        .append("upload", uploadSslContextUrl)
-        .build();
+      HalAppender.LinkArrayBuilder linkArrayBuilder = appender.linkArrayBuilder("sslContext");
+      linkArrayBuilder.append("rejected", rejected());
+      linkArrayBuilder.append("approved", approved());
+
+      if (PermissionChecker.mayManageSSLContext()) {
+        linkArrayBuilder.append("upload", upload());
+      }
+      linkArrayBuilder.build();
     }
+  }
+
+  private String upload() {
+    LinkBuilder linkBuilder = new LinkBuilder(pathInfoStore.get().get(), SSLContextResource.class);
+    return linkBuilder.method("uploadCertificate").parameters().href();
+  }
+
+  private String rejected() {
+    LinkBuilder linkBuilder = new LinkBuilder(pathInfoStore.get().get(), SSLContextResource.class);
+    return linkBuilder.method("getAllRejected").parameters().href();
+  }
+
+  private String approved() {
+    LinkBuilder linkBuilder = new LinkBuilder(pathInfoStore.get().get(), SSLContextResource.class);
+    return linkBuilder.method("getAllApproved").parameters().href();
   }
 }

--- a/src/main/java/com/cloudogu/sslcontext/PermissionChecker.java
+++ b/src/main/java/com/cloudogu/sslcontext/PermissionChecker.java
@@ -34,11 +34,15 @@ class PermissionChecker {
     return SecurityUtils.getSubject().isPermitted("sslcontext:read");
   }
 
+  public static boolean mayManageSSLContext() {
+    return SecurityUtils.getSubject().isPermitted("sslcontext:read,write");
+  }
+
   public static void checkReadSSLContext() {
     SecurityUtils.getSubject().checkPermission("sslcontext:read");
   }
 
   public static void checkManageSSLContext() {
-    SecurityUtils.getSubject().checkPermission("sslcontext:write");
+    SecurityUtils.getSubject().checkPermission("sslcontext:read,write");
   }
 }

--- a/src/main/js/SSLCertificateUpload.tsx
+++ b/src/main/js/SSLCertificateUpload.tsx
@@ -74,8 +74,13 @@ const SSLCertificateUpload: FC<Props> = ({ link, refresh }) => {
       .catch(setError);
   };
 
+  if (!link) {
+    return null;
+  }
+
   return (
     <>
+      <hr />
       <Subtitle subtitle={t("scm-ssl-context-plugin.upload.subtitle")} className="mb-3" />
       <FileInput
         onChange={(event: ChangeEvent<HTMLInputElement>) => setFile(event.target?.files?.[0])}

--- a/src/main/js/SSLContextOverview.tsx
+++ b/src/main/js/SSLContextOverview.tsx
@@ -50,7 +50,6 @@ const SSLContextOverview: FC<Props> = ({ links }) => {
       <SSLContextApprovedOverview {...approvedResult} refresh={refreshApproved} />
       <hr />
       <SSLContextRejectedOverview {...rejectedResult} refresh={refreshApproved} />
-      <hr/>
       <SSLCertificateUpload link={getLinkByName(links, "upload")} refresh={refreshApproved} />
     </>
   );

--- a/src/main/js/approved/ApprovedCertificateDetailsModal.tsx
+++ b/src/main/js/approved/ApprovedCertificateDetailsModal.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 import React, { FC, useState } from "react";
-import { Button, Checkbox, ErrorNotification, Level, Modal } from "@scm-manager/ui-components";
+import { Button, ErrorNotification, Level, Modal } from "@scm-manager/ui-components";
 import { useTranslation } from "react-i18next";
 import { Certificate, formatAsTimestamp, parseCommonNameFromDN } from "../certificates";
 import styled from "styled-components";
@@ -82,22 +82,6 @@ const ApprovedCertificateDetailsModal: FC<Props> = ({ onClose, certificate, acti
   const chain = [certificate, ...certificate._embedded.chain].reverse();
   const [selectedCert, setSelectedCert] = useState<Certificate>(certificate);
   const { loading, error, manage } = useManageCertificate(refresh, onClose);
-
-  const renderButton = () => {
-    if (!!selectedCert._links) {
-      if (selectedCert?._links.reject) {
-        return (
-          <Button
-            label={t("scm-ssl-context-plugin.table.reject")}
-            action={() => manage((selectedCert._links.reject as Link).href)}
-            color="info"
-            type="button"
-            loading={loading}
-          />
-        );
-      }
-    }
-  };
 
   const body = (
     <>
@@ -161,7 +145,22 @@ const ApprovedCertificateDetailsModal: FC<Props> = ({ onClose, certificate, acti
     </>
   );
 
-  const footer = <Level right={renderButton()} />;
+  let footer = null;
+  if (selectedCert?._links?.reject) {
+    footer = (
+      <Level
+        right={
+          <Button
+            label={t("scm-ssl-context-plugin.table.reject")}
+            action={() => manage((selectedCert._links.reject as Link).href)}
+            color="info"
+            type="button"
+            loading={loading}
+          />
+        }
+      />
+    );
+  }
 
   return (
     <SizedModal

--- a/src/main/js/certificates.ts
+++ b/src/main/js/certificates.ts
@@ -64,7 +64,7 @@ export const parseCommonNameFromDN = (dn: string) => {
 };
 
 export const getLinkByName = (links: Links, linkName: string) => {
-  return (links.sslContext as Link[]).filter(l => l.name === linkName)[0].href;
+  return (links.sslContext as Link[]).filter(l => l.name === linkName)[0]?.href;
 };
 
 export const formatAsTimestamp = (date: Date) => {

--- a/src/main/js/rejected/RejectedCertificateDetailsModal.tsx
+++ b/src/main/js/rejected/RejectedCertificateDetailsModal.tsx
@@ -42,22 +42,6 @@ const RejectedCertificateDetailsModal: FC<Props> = ({ onClose, certificate, acti
   const [selectedCert, setSelectedCert] = useState<Certificate>(certificate);
   const { loading, error, manage } = useManageCertificate(refresh, onClose);
 
-  const renderButton = () => {
-    if (!!selectedCert._links) {
-      if (selectedCert?._links.approve) {
-        return (
-          <Button
-            label={t("scm-ssl-context-plugin.table.approve")}
-            action={() => manage((selectedCert._links.approve as Link).href)}
-            color="info"
-            type="button"
-            loading={loading}
-          />
-        );
-      }
-    }
-  };
-
   const body = (
     <>
       <ErrorNotification error={error} />
@@ -117,7 +101,22 @@ const RejectedCertificateDetailsModal: FC<Props> = ({ onClose, certificate, acti
     </>
   );
 
-  const footer = <Level right={renderButton()} />;
+  let footer = null;
+  if (selectedCert?._links.approve) {
+    footer = (
+      <Level
+        right={
+          <Button
+            label={t("scm-ssl-context-plugin.table.approve")}
+            action={() => manage((selectedCert._links.approve as Link).href)}
+            color="info"
+            type="button"
+            loading={loading}
+          />
+        }
+      />
+    );
+  }
 
   return (
     <SizedModal

--- a/src/main/js/rejected/RejectedCertificateDetailsModal.tsx
+++ b/src/main/js/rejected/RejectedCertificateDetailsModal.tsx
@@ -102,7 +102,7 @@ const RejectedCertificateDetailsModal: FC<Props> = ({ onClose, certificate, acti
   );
 
   let footer = null;
-  if (selectedCert?._links.approve) {
+  if (selectedCert?._links?.approve) {
     footer = (
       <Level
         right={

--- a/src/main/resources/META-INF/scm/permissions.xml
+++ b/src/main/resources/META-INF/scm/permissions.xml
@@ -27,4 +27,7 @@
   <permission>
     <value>sslContext:read</value>
   </permission>
+  <permission>
+    <value>sslContext:read,write</value>
+  </permission>
 </permissions>

--- a/src/main/resources/locales/de/plugins.json
+++ b/src/main/resources/locales/de/plugins.json
@@ -50,6 +50,10 @@
       "read": {
         "displayName": "SSL Kontext Informationen lesen",
         "description": "Darf SSL Kontext Informationen lesen"
+      },
+      "read,write": {
+        "displayName": "SSL Kontext Informationen lesen und verwalten",
+        "description": "Darf SSL Kontext lesen und verwalten"
       }
     }
   },

--- a/src/main/resources/locales/en/plugins.json
+++ b/src/main/resources/locales/en/plugins.json
@@ -49,6 +49,10 @@
       "read": {
         "displayName": "Access ssl context information",
         "description": "May see the ssl context overview"
+      },
+      "read,write": {
+        "displayName": "Access and manage ssl context information",
+        "description": "May see and manage the ssl context"
       }
     }
   },

--- a/src/test/java/com/cloudogu/sslcontext/CertificateCollectionMapperTest.java
+++ b/src/test/java/com/cloudogu/sslcontext/CertificateCollectionMapperTest.java
@@ -27,8 +27,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.util.Providers;
 import de.otto.edison.hal.HalRepresentation;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.github.sdorra.jse.ShiroExtension;
+import org.github.sdorra.jse.SubjectAware;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import sonia.scm.api.v2.resources.ScmPathInfo;
 import sonia.scm.api.v2.resources.ScmPathInfoStore;
 
@@ -47,6 +50,8 @@ import static com.cloudogu.sslcontext.Certificate.Status.APPROVED;
 import static com.cloudogu.sslcontext.Certificate.Status.REJECTED;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SubjectAware(value = "trillian", permissions = "sslContext:read,write")
+@ExtendWith(ShiroExtension.class)
 class CertificateCollectionMapperTest {
 
   static {

--- a/src/test/java/com/cloudogu/sslcontext/CertificateMapperTest.java
+++ b/src/test/java/com/cloudogu/sslcontext/CertificateMapperTest.java
@@ -26,8 +26,11 @@ package com.cloudogu.sslcontext;
 import com.google.common.io.Resources;
 import com.google.inject.util.Providers;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.github.sdorra.jse.ShiroExtension;
+import org.github.sdorra.jse.SubjectAware;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import sonia.scm.api.v2.resources.ScmPathInfo;
 import sonia.scm.api.v2.resources.ScmPathInfoStore;
 
@@ -40,6 +43,7 @@ import static com.cloudogu.sslcontext.Certificate.Error.EXPIRED;
 import static com.cloudogu.sslcontext.Certificate.Error.UNKNOWN;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+@ExtendWith(ShiroExtension.class)
 class CertificateMapperTest {
 
   static {
@@ -58,6 +62,7 @@ class CertificateMapperTest {
 
   @Test
   @SuppressWarnings("UnstableApiUsage")
+  @SubjectAware(value = "trillian", permissions = "sslContext:read,write")
   void shouldMapToDto() throws IOException {
     URL resource = Resources.getResource("com/cloudogu/sslcontext/cert-001");
     byte[] encoded = Resources.toByteArray(resource);
@@ -75,6 +80,7 @@ class CertificateMapperTest {
 
   @Test
   @SuppressWarnings("UnstableApiUsage")
+  @SubjectAware(value = "trillian", permissions = "sslContext:read,write")
   void shouldMapNestedChainCertsToDto() throws IOException {
     URL resource1 = Resources.getResource("com/cloudogu/sslcontext/cert-001");
     URL resource2 = Resources.getResource("com/cloudogu/sslcontext/cert-002-expired");
@@ -100,6 +106,7 @@ class CertificateMapperTest {
 
   @Test
   @SuppressWarnings("UnstableApiUsage")
+  @SubjectAware(value = "trillian", permissions = "sslContext:read,write")
   void shouldMapToDtoWithApproveLink() throws IOException {
     URL resource = Resources.getResource("com/cloudogu/sslcontext/cert-001");
     byte[] encoded = Resources.toByteArray(resource);
@@ -113,6 +120,20 @@ class CertificateMapperTest {
 
   @Test
   @SuppressWarnings("UnstableApiUsage")
+  @SubjectAware(value = "maximilius", permissions = "sslContext:read")
+  void shouldNotMapToDtoWithApproveLink() throws IOException {
+    URL resource = Resources.getResource("com/cloudogu/sslcontext/cert-001");
+    byte[] encoded = Resources.toByteArray(resource);
+    Certificate certificate = new Certificate(encoded, UNKNOWN);
+
+    CertificateDto dto = mapper.map(certificate);
+
+    assertThat(dto.getLinks().getLinkBy("approve")).isNotPresent();
+  }
+
+  @Test
+  @SuppressWarnings("UnstableApiUsage")
+  @SubjectAware(value = "trillian", permissions = "sslContext:read,write")
   void shouldMapToDtoWithRejectLink() throws IOException {
     URL resource = Resources.getResource("com/cloudogu/sslcontext/cert-001");
     byte[] encoded = Resources.toByteArray(resource);
@@ -127,6 +148,7 @@ class CertificateMapperTest {
 
   @Test
   @SuppressWarnings("UnstableApiUsage")
+  @SubjectAware(value = "trillian", permissions = "sslContext:read,write")
   void shouldNotMapRejectLinkNorApproveLink() throws IOException {
     URL resource = Resources.getResource("com/cloudogu/sslcontext/cert-001");
     byte[] encoded = Resources.toByteArray(resource);
@@ -141,6 +163,7 @@ class CertificateMapperTest {
 
   @Test
   @SuppressWarnings("UnstableApiUsage")
+  @SubjectAware(value = "trillian", permissions = "sslContext:read,write")
   void shouldMapApproveLinkToChainCert() throws IOException {
     URL resource1 = Resources.getResource("com/cloudogu/sslcontext/cert-001");
     URL resource2 = Resources.getResource("com/cloudogu/sslcontext/cert-002-expired");

--- a/src/test/java/com/cloudogu/sslcontext/IndexLinkEnricherTest.java
+++ b/src/test/java/com/cloudogu/sslcontext/IndexLinkEnricherTest.java
@@ -68,7 +68,20 @@ class IndexLinkEnricherTest {
 
   @Test
   @SubjectAware(permissions = "sslContext:read")
-  void shouldAppendLinks() {
+  void shouldAppendReadLinks() {
+    HalAppender.LinkArrayBuilder linkArrayBuilder = mock(HalAppender.LinkArrayBuilder.class, RETURNS_SELF);
+    when(appender.linkArrayBuilder("sslContext")).thenReturn(linkArrayBuilder);
+
+    when(scmPathInfoStore.get()).thenReturn(() -> URI.create("/scm/"));
+    enricher.enrich(context, appender);
+
+    verify(linkArrayBuilder).append("rejected", "/scm/v2/ssl-context/rejected");
+    verify(linkArrayBuilder).append("approved", "/scm/v2/ssl-context/approved");
+  }
+
+  @Test
+  @SubjectAware(permissions = "sslContext:read,write")
+  void shouldAppendManageLinks() {
     HalAppender.LinkArrayBuilder linkArrayBuilder = mock(HalAppender.LinkArrayBuilder.class, RETURNS_SELF);
     when(appender.linkArrayBuilder("sslContext")).thenReturn(linkArrayBuilder);
 


### PR DESCRIPTION
## Proposed changes

The post methods for upload, approve, reject are only available with `sslcontext:read,write` permission.
This was already the case before. Now, however, the actions are only displayed in the interface with the corresponding permission. With `sslcontext:read` only the SSL context information can be retrieved.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [x] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
